### PR TITLE
Cambio nombre del directorio en Jenkins-File

### DIFF
--- a/temas/inyeccion/java-01/Jenkinsfile
+++ b/temas/inyeccion/java-01/Jenkinsfile
@@ -4,7 +4,7 @@ pipeline {
     stages {
         stage('Compilar') {
             steps {
-                dir('temas/inyeccion/java') {
+                dir('temas/inyeccion/java-01') {
                     echo 'Compilando el proyecto...'
                     sh 'mvn clean compile'
                 }
@@ -13,7 +13,7 @@ pipeline {
 
         stage('Test de MainTest.java') {
             steps {
-                dir('temas/inyeccion/java') {
+                dir('temas/inyeccion/java-01') {
                     echo 'Ejecutando programa principal...'
                     sh 'mvn test'
                 }


### PR DESCRIPTION
Cambio del directorio de una carpeta que hacía que Jenkins no reconociera la carpeta correspondiente.